### PR TITLE
List prompt templates in use

### DIFF
--- a/main.js
+++ b/main.js
@@ -234,7 +234,7 @@ async function summarizeWithPollinations(text, lang="es"){
 
 function buildSummaryPrompt(text, lang){
   const trimmed = text.replace(/\s+/g," ").trim().slice(0, 600);
-  return `Given this new, provide a funny caricaturized and comedic summary of the news, keep the original language: ${trimmed}`;
+  return `Make sure to keep the original language of the provided text. Given this news report, provide a funny caricaturized and comedic summary of the news, keep the original language: ${trimmed}`;
 }
 
 // --- Helpers & utilities ---


### PR DESCRIPTION
Update the summary prompt to improve clarity and emphasize language preservation.

---
<a href="https://cursor.com/background-agent?bcId=bc-053fab3f-70e4-49b4-b5fe-1c2b4c52f510">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-053fab3f-70e4-49b4-b5fe-1c2b4c52f510">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

